### PR TITLE
Infra

### DIFF
--- a/ansible/.gitignore
+++ b/ansible/.gitignore
@@ -1,3 +1,4 @@
 
 # ignore .docker/config.json auth token file.
 .docker
+*.play.logs

--- a/ansible/notes
+++ b/ansible/notes
@@ -1,0 +1,26 @@
+kubectl create secret docker-registry docker-registry --from-file ~/.docker/config.json
+kubectl patch serviceaccount default -p '{"imagePullSecrets": [{"name": "docker-registry"}]}'
+
+
+cc@node1:~$ cat init.sql
+-- init.sql
+
+CREATE USER testuser WITH PASSWORD 'testpassword';
+CREATE DATABASE testdb OWNER testuser;
+
+
+kubectl create secret generic pg-init-secret --from-file=init.sql
+
+curl https://rclone.org/install.sh | sudo bash
+sudo sed -i '/^#user_allow_other/s/^#//' /etc/fuse.conf
+mkdir -p ~/.config/rclone
+# Copy rclone.conf file.
+
+kubectl create secret generic rclone-conf --from-file=rclone.conf=.config/rclone/rclone.conf
+
+https://github.com/wunderio/csi-rclone
+
+1. setup csi-rclone drivers and mount minio.
+2. setup postgres and mount on top of block storage local path.
+
+

--- a/ansible/scripts.sh
+++ b/ansible/scripts.sh
@@ -1,14 +1,25 @@
 #!/bin/bash
 
 
-ansible all -i /inventory/myclusters -m ping
+function play_ping() {
+    ansible all -i /inventory/myclusters -m ping
+}
 
 
-function ansible_play() {
-    ansible-playbook -i "/inventory/myclusters" /inventory/pre_k8s/pre_k8s_configure.yml && \
-    ansible-playbook -i "/inventory/myclusters" /inventory/docker-login.yml && \
-    ansible-playbook -i "/inventory/myclusters" cluster.yml --become --become-user=root  && \
+function play_pre_k8s() {
+    ansible-playbook -i "/inventory/myclusters" /inventory/pre_k8s/pre_k8s_configure.yml
+}
+
+function play_build_k8s_cluster() {
+    ansible-playbook -i "/inventory/myclusters/${1}" cluster.yml --become --become-user=root \
+        > "/inventory/${1}.play.logs" 2>&1
+}
+
+function play_post_k8s() {
     ansible-playbook -i "/inventory/myclusters" /inventory/post_k8s/post_k8s_configure.yml
 }
 
-ansible_play > /inventory/play.logs 2>&1
+function play_block_mount() {
+    ansible-playbook -i "/inventory/myclusters/kvm_tacc" /inventory/test/mount.yml
+}
+

--- a/ansible/test/mount.yml
+++ b/ansible/test/mount.yml
@@ -1,0 +1,12 @@
+- name: Mount block storage on primary node.
+  hosts: node1
+  become: yes
+  gather_facts: yes
+  tasks:
+    - name: Mount filesystem
+      ansible.posix.mount:
+        path: /mnt/block
+        src: /dev/vdb1
+        fstype: ext4
+        opts: rw,noauto
+        state: mounted

--- a/kubernetes/.gitignore
+++ b/kubernetes/.gitignore
@@ -1,0 +1,5 @@
+
+
+# ignore kubernetes secrets config files.
+*.secrets.yaml
+*.secret.yaml

--- a/kubernetes/csi-rclone/README.md
+++ b/kubernetes/csi-rclone/README.md
@@ -1,0 +1,8 @@
+# CSI Driver for creating StorageVolumes with rclone configs
+
+
+```
+https://github.com/wunderio/csi-rclone
+```
+
+

--- a/kubernetes/csi-rclone/_csi-rclone-namespace.yaml
+++ b/kubernetes/csi-rclone/_csi-rclone-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: csi-rclone

--- a/kubernetes/csi-rclone/csi-controller-rbac.yaml
+++ b/kubernetes/csi-rclone/csi-controller-rbac.yaml
@@ -1,0 +1,66 @@
+# This YAML file contains RBAC API objects that are necessary to run external
+# CSI attacher for rclone adapter
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-controller-rclone
+  namespace: csi-rclone
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: external-controller-rclone
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "patch", "update", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["csi.storage.k8s.io"]
+    resources: ["csinodeinfos"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "update", "create", "delete"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments/status"]
+    verbs: ["patch"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "create", "update"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["get", "list"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents"]
+    verbs: ["get", "list"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["csinodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-attacher-role-rclone
+subjects:
+  - kind: ServiceAccount
+    name: csi-controller-rclone
+    namespace: csi-rclone
+roleRef:
+  kind: ClusterRole
+  name: external-controller-rclone
+  apiGroup: rbac.authorization.k8s.io

--- a/kubernetes/csi-rclone/csi-controller-rclone.yaml
+++ b/kubernetes/csi-rclone/csi-controller-rclone.yaml
@@ -1,0 +1,69 @@
+# This YAML file contains attacher & csi driver API objects that are necessary
+# to run external CSI attacher for rclone
+
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: csi-controller-rclone
+  namespace: csi-rclone
+spec:
+  serviceName: "csi-controller-rclone"
+  replicas: 1
+  selector:
+    matchLabels:
+      app: csi-controller-rclone
+  template:
+    metadata:
+      labels:
+        app: csi-controller-rclone
+    spec:
+      serviceAccountName: csi-controller-rclone
+      containers:
+        - name: csi-provisioner
+          image: registry.k8s.io/sig-storage/csi-provisioner:v5.0.2
+          args:
+            - "--csi-address=$(ADDRESS)"
+            - "--extra-create-metadata"
+            # - "--leader-election"
+            - "--v=1"
+          env:
+            - name: ADDRESS
+              value: /plugin/csi.sock
+          imagePullPolicy: "Always"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /plugin
+        - name: csi-attacher
+          image: k8s.gcr.io/sig-storage/csi-attacher:v3.4.0
+          args:
+            - "--csi-address=$(ADDRESS)"
+            - "--v=1"
+            # - "--leader-election"
+          env:
+            - name: ADDRESS
+              value: /plugin/csi.sock
+          imagePullPolicy: "Always"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /plugin
+        - name: rclone
+          image: wunderio/csi-rclone:v3.0.0
+          args :
+            - "/bin/csi-rclone-plugin"
+            - "--nodeid=$(NODE_ID)"
+            - "--endpoint=$(CSI_ENDPOINT)"
+            - "--v=1"
+          env:
+            - name: NODE_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: CSI_ENDPOINT
+              value: unix://plugin/csi.sock
+          imagePullPolicy: "Always"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /plugin
+      volumes:
+        - name: socket-dir
+          emptyDir: {}

--- a/kubernetes/csi-rclone/csi-driver.yaml
+++ b/kubernetes/csi-rclone/csi-driver.yaml
@@ -1,0 +1,8 @@
+# this should be deregistered once the controller stops
+apiVersion: storage.k8s.io/v1
+kind: CSIDriver
+metadata:
+  name: csi-rclone
+spec:
+  attachRequired: true
+  podInfoOnMount: true

--- a/kubernetes/csi-rclone/csi-nodeplugin-rbac.yaml
+++ b/kubernetes/csi-rclone/csi-nodeplugin-rbac.yaml
@@ -1,0 +1,40 @@
+# This YAML defines all API objects to create RBAC roles for CSI node plugin
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-nodeplugin-rclone
+  namespace: csi-rclone
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-nodeplugin-rclone
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: [""]
+    resources: ["secrets","secret"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-nodeplugin-rclone
+subjects:
+  - kind: ServiceAccount
+    name: csi-nodeplugin-rclone
+    namespace: csi-rclone
+roleRef:
+  kind: ClusterRole
+  name: csi-nodeplugin-rclone
+  apiGroup: rbac.authorization.k8s.io

--- a/kubernetes/csi-rclone/csi-nodeplugin-rclone.yaml
+++ b/kubernetes/csi-rclone/csi-nodeplugin-rclone.yaml
@@ -1,0 +1,83 @@
+# This YAML file contains driver-registrar & csi driver nodeplugin API objects
+# that are necessary to run CSI nodeplugin for rclone
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: csi-nodeplugin-rclone
+  namespace: csi-rclone
+spec:
+  selector:
+    matchLabels:
+      app: csi-nodeplugin-rclone
+  template:
+    metadata:
+      labels:
+        app: csi-nodeplugin-rclone
+    spec:
+      serviceAccountName: csi-nodeplugin-rclone
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      containers:
+        - name: node-driver-registrar
+          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.4.0
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "rm -rf /registration/csi-rclone /registration/csi-rclone-reg.sock"]
+          args:
+            - --v=1
+            - --csi-address=/plugin/csi.sock
+            - --kubelet-registration-path=/var/lib/kubelet/plugins/csi-rclone/csi.sock
+          env:
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /plugin
+            - name: registration-dir
+              mountPath: /registration
+        - name: rclone
+          securityContext:
+            privileged: true
+            capabilities:
+              add: ["SYS_ADMIN"]
+            allowPrivilegeEscalation: true
+          image: wunderio/csi-rclone:v3.0.0
+          args:
+            - "/bin/csi-rclone-plugin"
+            - "--nodeid=$(NODE_ID)"
+            - "--endpoint=$(CSI_ENDPOINT)"
+            - "--v=1"
+          env:
+            - name: NODE_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: CSI_ENDPOINT
+              value: unix://plugin/csi.sock
+          imagePullPolicy: "Always"
+          lifecycle:
+            postStart:
+              exec:
+                command: ["/bin/sh", "-c", "mount -t fuse.rclone | while read -r mount; do umount $(echo $mount | awk '{print $3}') || true ; done"]
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /plugin
+            - name: pods-mount-dir
+              mountPath: /var/lib/kubelet/pods
+              mountPropagation: "Bidirectional"
+      volumes:
+        - name: plugin-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/csi-rclone
+            type: DirectoryOrCreate
+        - name: pods-mount-dir
+          hostPath:
+            path: /var/lib/kubelet/pods
+            type: Directory
+        - hostPath:
+            path: /var/lib/kubelet/plugins_registry
+            type: DirectoryOrCreate
+          name: registration-dir

--- a/kubernetes/csi-rclone/csi-rclone-storageclass.yaml
+++ b/kubernetes/csi-rclone/csi-rclone-storageclass.yaml
@@ -1,0 +1,11 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: rclone
+provisioner: csi-rclone
+parameters:
+  remote: chi_tacc
+  pathPattern: "${.PVC.annotations.csi-rclone/storage-path}"
+reclaimPolicy: Delete
+volumeBindingMode: Immediate
+

--- a/kubernetes/csi-rclone/rclone-config.secret.yaml.template
+++ b/kubernetes/csi-rclone/rclone-config.secret.yaml.template
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rclone-secret
+  namespace: csi-rclone
+type: Opaque
+stringData:
+  remote: "chi_tacc"
+  remotePath: "object-persist-project-22"
+  configData: |
+    [chi_tacc]
+    type = swift
+    user_id = rg5073
+    application_credential_id = 89dacc**************************
+    application_credential_secret = lmHrM*********************************************************************************
+    auth = https://chi.tacc.chameleoncloud.org:5000/v3
+    region = CHI@TACC

--- a/kubernetes/minio/minio.secrets.yaml.template
+++ b/kubernetes/minio/minio.secrets.yaml.template
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: minio
+type: Opaque
+stringData:
+  MINIO_ROOT_USER: "********"
+  MINIO_ROOT_PASSWORD: "*********" 

--- a/kubernetes/minio/minio.yaml
+++ b/kubernetes/minio/minio.yaml
@@ -1,0 +1,67 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: minio
+  annotations:
+    csi-rclone/remotePath: "object-persist-project-22"
+    csi-rclone/storage-path: minio
+    csi-rclone/umask: "022"
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 500Gi
+  storageClassName: rclone
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: minio
+  labels:
+    app: minio
+    set: training
+spec:
+  containers:
+    - name: minio
+      image: minio/minio
+      args: ["server", "/data", "--console-address", ":9001"]
+      env:
+        - name: MINIO_ROOT_USER
+          valueFrom:
+            secretKeyRef:
+              name: minio
+              key: MINIO_ROOT_USER
+        - name: MINIO_ROOT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: minio
+              key: MINIO_ROOT_PASSWORD
+      ports:
+        - containerPort: 9000  # S3 API
+        - containerPort: 9001  # Dashboard
+      volumeMounts:
+        - name: object-store
+          mountPath: /data
+  volumes:
+    - name: object-store
+      persistentVolumeClaim:
+        claimName: minio
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio
+spec:
+  selector:
+    app: minio
+  ports:
+    - name: s3
+      port: 9000
+      targetPort: 9000
+    - name: console
+      port: 9001
+      targetPort: 9001
+  type: ClusterIP
+

--- a/kubernetes/postgres/postgres.secret.yaml.template
+++ b/kubernetes/postgres/postgres.secret.yaml.template
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgres
+type: Opaque
+stringData:
+  POSTGRES_USER: "********"
+  POSTGRES_PASSWORD: "*********"

--- a/kubernetes/postgres/postgres.yaml
+++ b/kubernetes/postgres/postgres.yaml
@@ -1,0 +1,81 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: postgres
+spec:
+  capacity:
+    storage: 500Mi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: manual
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: kubernetes.io/hostname
+              operator: In
+              values:
+                - node1
+  hostPath:
+    path: /mnt/block/postgres
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgres
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 500Mi
+  storageClassName: manual
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: postgres
+  labels:
+    app: postgres
+    set: training
+spec:
+  nodeSelector:
+    kubernetes.io/hostname: node1
+  containers:
+    - name: postgres
+      image: postgres:latest
+      env:
+        - name: POSTGRES_USER
+          valueFrom:
+            secretKeyRef:
+              name: postgres
+              key: POSTGRES_USER
+        - name: POSTGRES_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: postgres
+              key: POSTGRES_PASSWORD
+      ports:
+        - containerPort: 5432
+      volumeMounts:
+        - name: block-store
+          mountPath: /var/lib/postgresql/data 
+  volumes:
+    - name: block-store
+      persistentVolumeClaim:
+        claimName: postgres
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+spec:
+  selector:
+    app: postgres
+  ports:
+    - name: db
+      port: 5432
+      targetPort: 5432
+  type: ClusterIP
+

--- a/terraform/create_reservation.sh
+++ b/terraform/create_reservation.sh
@@ -8,7 +8,7 @@ function create_reservation() {
     openstack reservation lease create \
       --reservation min=1,max=1,resource_type=physical:host,resource_properties='["=", "$node_type", "gpu_rtx_6000"]' \
       --start-date "$(date -u +"%Y-%m-%d %H:%M")" \
-      --end-date "$(date -u -v+6H +"%Y-%m-%d %H:%M")" \
+      --end-date "$(date -u -v+8H +"%Y-%m-%d %H:%M")" \
       "$RESERVATION"
 
     while true; do

--- a/terraform/kvm_tacc/main.tf
+++ b/terraform/kvm_tacc/main.tf
@@ -95,6 +95,11 @@ resource "openstack_compute_instance_v2" "nodes" {
 
 }
 
+resource "openstack_compute_volume_attach_v2" "attach_volume" {
+    volume_id = "${var.volume_id}"
+    instance_id = openstack_compute_instance_v2.nodes["node1"].id
+}
+
 resource "openstack_networking_floatingip_v2" "floating_ip" {
   pool        = "public"
   description = "MLOps IP for ${var.suffix}"

--- a/terraform/kvm_tacc/variables.tf
+++ b/terraform/kvm_tacc/variables.tf
@@ -5,16 +5,17 @@ variable "suffix" {
   default = "project22"
 }
 
-#variable "reservation_id" {
-#    description = "Reservation ID"
-#    type = string
-#    nullable = false
-#}
+variable "volume_id" {
+    description = "The Volume ID to attach node1 to"
+    type = string
+    nullable = false
+    default = "96be5163-ab12-4477-9180-558cedf9f772"
+}
 
 variable "key" {
   description = "Name of key pair"
   type        = string
-  default     = "Preetham Rakshith"
+  default     = "ghost"
 }
 
 variable "nodes" {


### PR DESCRIPTION
- Added csi-rclone drivers to manage chameleon's ceph object store on our kube cluster.
- Fully working kube cluster bootstrapping with ansible on both KVM@TACC and CHI@UC.
- Mountable postgres and minio pods over block and object stores fully ready.
- Terraform script for KVM@TACC fully complete with block store attch for node1.
- Added support for managing kube secrets.